### PR TITLE
Fix error missing option ressource_dir

### DIFF
--- a/phenogenius_cli.py
+++ b/phenogenius_cli.py
@@ -311,7 +311,7 @@ def evaluate_matching(result_file, hpo_list, gene_list, resource_dir):
 
         else:
             logging.info("INFO: selected symptom interaction model - node similarity")
-            similarity_terms_dict = load_similarity_dict()
+            similarity_terms_dict = load_similarity_dict(resource_dir)
             sim_dict, hpo_list_add_raw = get_similar_terms(
                 hpo_list, similarity_terms_dict
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PhenoGenius_cli"
-version = "1.1.2"
+version = "1.1.3"
 description = ""
 authors = ["kevin.yauy <kevin.yauy@chu-montpellier.fr>"]
 


### PR DESCRIPTION
The function load_similarity_dict has a required parameter "resource_dir" doesn't fill in main function. I fix this bug in this pull request